### PR TITLE
Duplicate props.data (prevent props mutation)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -285,7 +285,7 @@ class DraggableFlatList extends Component {
         const tappedRowSave = this._tappedRow;
         const from = this._tappedRow;
         const to = this._spacerIndex;
-        const sortedData = this.arrayMove(data, from, to);
+        const sortedData = this.arrayMove([...data], from, to);
         this._size = this.arrayMove(this._size, from, to);
         for (let i = 0; i < data.length; i++) {
             this._order[i] = i;


### PR DESCRIPTION
The function `arrayMove` changes the array it receives, and it is used to change a prop (React components should not mutate own props).

https://github.com/thomasrovayaz/react-native-draggable-dynamic-flatlist/blob/f8dd72f470101d77286f538cfb16f6bb900a480e/src/index.js#L283-L288

https://github.com/thomasrovayaz/react-native-draggable-dynamic-flatlist/blob/f8dd72f470101d77286f538cfb16f6bb900a480e/src/index.js#L313-L322

The solution is to clone the data before passing it to the `arrayMove` function:

```js
const sortedData = this.arrayMove([...data], from, to);
```