### PR TITLE
optional removeClippedSubviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Name | Type | Description
 `scaleSelectionFactor` | Number | Sets the scale factor of the selected item. 
 `onMoveEnd` | Function | `({ data, to, from, row }) => void` Returns updated ordering of `data` 
 `onMoveBegin` | Function | `(index) => void` Called when row becomes active.
+`removeClippedSubviews` | Boolean | Improve scroll performance for large lists. May have bugs (missing content) in some circumstances (Default `false`)
 
 ## Example
 

--- a/src/index.js
+++ b/src/index.js
@@ -426,7 +426,7 @@ class DraggableFlatList extends Component {
                 <FlatList
                     {...this.props}
                     ListHeaderComponent={this.renderHeaderComponent}
-                    removeClippedSubviews
+                    removeClippedSubviews={this.props.removeClippedSubviews}
                     scrollEnabled={this._tappedRow === -1}
                     ref={ref => this._flatList = ref}
                     renderItem={this.renderItem}
@@ -448,7 +448,8 @@ export default DraggableFlatList
 DraggableFlatList.defaultProps = {
     scrollPercent: 5,
     scrollSpeed: 10,
-    scaleSelectionFactor: 1.02
+    scaleSelectionFactor: 1.02,
+    removeClippedSubviews: false
 };
 
 class RowItem extends React.PureComponent {


### PR DESCRIPTION
removeClippedSubviews property is known to be buggy and in most cases at least on iOS list renders blank