### PR TITLE
Fix: onScroll can't be called

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -285,7 +285,7 @@ class DraggableFlatList extends Component {
         const tappedRowSave = this._tappedRow;
         const from = this._tappedRow;
         const to = this._spacerIndex;
-        const sortedData = this.arrayMove([...data], from, to);
+        const sortedData = this.arrayMove(data, from, to);
         this._size = this.arrayMove(this._size, from, to);
         for (let i = 0; i < data.length; i++) {
             this._order[i] = i;

--- a/src/index.js
+++ b/src/index.js
@@ -406,7 +406,7 @@ class DraggableFlatList extends Component {
     keyExtractor = (item, index) => `sortable-flatlist-item-${index}`;
 
     render() {
-        const { horizontal, keyExtractor, onScroll } = this.props;
+        const { horizontal, keyExtractor } = this.props;
 
         return (
             <View
@@ -434,7 +434,6 @@ class DraggableFlatList extends Component {
                     keyExtractor={keyExtractor || this.keyExtractor}
                     onScroll={({ nativeEvent }) => {
                         this._scrollOffset = nativeEvent.contentOffset[horizontal ? 'x' : 'y'];
-                        if (onScroll) onScroll(nativeEvent);
                     } }
                     scrollEventThrottle={16}
                 />

--- a/src/index.js
+++ b/src/index.js
@@ -406,7 +406,7 @@ class DraggableFlatList extends Component {
     keyExtractor = (item, index) => `sortable-flatlist-item-${index}`;
 
     render() {
-        const { horizontal, keyExtractor } = this.props;
+        const { horizontal, keyExtractor, onScroll } = this.props;
 
         return (
             <View
@@ -434,6 +434,7 @@ class DraggableFlatList extends Component {
                     keyExtractor={keyExtractor || this.keyExtractor}
                     onScroll={({ nativeEvent }) => {
                         this._scrollOffset = nativeEvent.contentOffset[horizontal ? 'x' : 'y'];
+                        if (onScroll) onScroll(nativeEvent);
                     } }
                     scrollEventThrottle={16}
                 />


### PR DESCRIPTION
onScroll prop didn't seem to be passed down to the underlying Flatlist. This pr should take care of this.