### PR TITLE
Issue #19 fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-draggable-dynamic-flatlist",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A react native component that lets you drag and drop dynamic items of a FlatList.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import {
-    YellowBox,
+    LogBox,
     Animated,
     FlatList,
     View,
@@ -10,7 +10,7 @@ import {
 } from 'react-native'
 
 // Measure function triggers false positives
-YellowBox.ignoreWarnings(['Warning: isMounted(...) is deprecated']);
+LogBox.ignoreLogs(['Warning: isMounted(...) is deprecated', 'Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false`']);
 UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
 
 const initialState = {


### PR DESCRIPTION
Multiple changes for log warnings:
- Use LogBox instead of YellowBox as YellowBox is now deprecated
- Add `useNativeDriver` warning to list of warnings to suppress; this doesn't appear to be
  fixable as per the react-native documentation.
- Bump up package version in package.json file